### PR TITLE
feat: hide help from desk toolbar, hide help youtube videos

### DIFF
--- a/white_theme/hooks.py
+++ b/white_theme/hooks.py
@@ -16,11 +16,11 @@ app_license = "MIT"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/white_theme/css/white_theme.css"
-app_include_js = "/assets/white_theme/js/help_menu.js"
+app_include_js = "/assets/white_theme/js/desk_toolbar.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/white_theme/css/white_theme.css"
-# web_include_js = "/assets/white_theme/js/white_theme.js"
+# web_include_js = "/assets/white_theme/js/help_menu.js"
 
 # include js in page
 # page_js = {"page" : "public/js/file.js"}

--- a/white_theme/patches.txt
+++ b/white_theme/patches.txt
@@ -1,0 +1,1 @@
+white_theme.patches.whitelabel

--- a/white_theme/patches/whitelabel.py
+++ b/white_theme/patches/whitelabel.py
@@ -1,0 +1,6 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+    # frappe.db.sql("""update help set intro='',content=''""")
+    frappe.db.sql("""delete from tabPage where name='welcome-to-erpnext'""")

--- a/white_theme/public/js/desk_toolbar.js
+++ b/white_theme/public/js/desk_toolbar.js
@@ -1,0 +1,3 @@
+$(window).load(function(){
+        $('.dropdown-help').hide();
+});

--- a/white_theme/public/js/desk_toolbar.js
+++ b/white_theme/public/js/desk_toolbar.js
@@ -1,3 +1,7 @@
+frappe.provide("frappe.help");
+
 $(window).load(function(){
         $('.dropdown-help').hide();
 });
+frappe.help.show_video = function(youtube_id, title) {
+}

--- a/white_theme/public/js/help_menu.js
+++ b/white_theme/public/js/help_menu.js
@@ -1,4 +1,0 @@
-$(function() {
-        $('.dropdown-help').hide();  // or .remove();
-});
-


### PR DESCRIPTION
**Changes:**

1. hide help option from desk toolbar

2. Disable opening help youtube videos

3. patch that deletes the E welcome page 

**Changes in action:**

![hide-help](https://user-images.githubusercontent.com/13060550/85397761-c5a3ce00-b571-11ea-88a8-3b729ae69655.gif)
